### PR TITLE
Added 'noClick' as an option to disable the click response

### DIFF
--- a/i18n.ts
+++ b/i18n.ts
@@ -2,42 +2,48 @@ export const TRANSLATION_EN = new Map<string, string>([
 	["toggleMouseShortcuts", "Fullscreen toggle shortcut"],
 	["toggleMouseShortcutsDes", "The number of consecutive mouse or touchscreen clicks, with a time interval between two clicks less than 300ms."],
 	["doubleClick", "double click"],
-	["tripleClick", "triple click"]
+	["tripleClick", "triple click"],
+	["noClick", "do not trigger on clicks"]
 ]);
 
 export const TRANSLATION_CH = new Map<string, string>([
 	["toggleMouseShortcuts", "全屏切换快捷键"],
 	["toggleMouseShortcutsDes", "鼠标或触屏连续点击次数，两次点击时间间隔需小于300ms。"],
 	["doubleClick", "双击"],
-	["tripleClick", "三连击"]
+	["tripleClick", "三连击"],
+	["noClick", "没有点击"]
 ]);
 
 export const TRANSLATION_JA = new Map<string, string>([
 	["toggleMouseShortcuts", "フルスクリーン切り替えショートカット"],
 	["toggleMouseShortcutsDes", "マウスまたはタッチスクリーンの連続クリック回数、2回のクリック間隔は300ms未満である必要があります"],
 	["doubleClick", "ダブルクリック"],
-	["tripleClick", "トリプルクリック"]
+	["tripleClick", "トリプルクリック"],
+	["noClick", "クリックなし"]
 ]);
 
 export const TRANSLATION_KO = new Map<string, string>([
 	["toggleMouseShortcuts", "전체 화면 전환 바로 가기"],
 	["toggleMouseShortcutsDes", "마우스 또는 터치스크린 연속 클릭 횟수, 2회 클릭 간격은 300ms 미만이어야 합니다"],
 	["doubleClick", "더블 클릭"],
-	["tripleClick", "트리플 클릭"]
+	["tripleClick", "트리플 클릭"],
+	["noClick", "클릭 없음"]
 ]);
 
 export const TRANSLATION_UK = new Map<string, string>([
 	["toggleMouseShortcuts", "Горячая клавиша переключения полноэкранного режима"],
 	["toggleMouseShortcutsDes", "оличество последовательных кликов мыши или сенсорного экрана с интервалом времени менее 300 мс"],
 	["doubleClick", "Двойной щелчок"],
-	["tripleClick", "Тройной щелчок"]
+	["tripleClick", "Тройной щелчок"],
+	["noClick", "нет кликов"]
 ]);
 
 export const TRANSLATION_TW = new Map<string, string>([
 	["toggleMouseShortcuts", "全螢幕切換快速鍵"],
 	["toggleMouseShortcutsDes", "鼠標或觸控螢幕連點次數，兩次點擊時間間隔需小於300毫秒"],
 	["doubleClick", "雙擊"],
-	["tripleClick", "三擊"]
+	["tripleClick", "三擊"],
+	["noClick", "沒有點擊"]
 ]);
 export const TRANSLATION = new Map<string, Map<string, string>>([
 	['en', TRANSLATION_EN],
@@ -53,7 +59,8 @@ export const TRANSLATION = new Map<string, Map<string, string>>([
 // 	["toggleMouseShortcuts", ""],
 // 	["toggleMouseShortcutsDes", ""],
 // 	["doubleClick", ""],
-// 	["tripleClick", ""]
+// 	["tripleClick", ""],
+// 	["noClick", ""]
 // ]);
 
 export class I18n {

--- a/main.ts
+++ b/main.ts
@@ -125,6 +125,7 @@ class SettingTab extends PluginSettingTab {
 				component
 					.addOption('2', i18n.t("doubleClick"))
 					.addOption('3', i18n.t("tripleClick"))
+					.addOption('-1', i18n.t("noClick"))
 					.setValue(this.plugin.settings.consecutiveClickTimes.toString())
 					.onChange((value) => {
 						this.plugin.settings.consecutiveClickTimes = parseInt(value);


### PR DESCRIPTION
Hi @DonkeyPacific, thanks for the plugin! I made some microscopic tweaks to give me a "do not activate on clicks at all" option (my frenetic clicking tends to fire it off randomly). Thought you may like to know about the use case (and maybe integrate a version of it into the plugin).

I kept the changes minimal since I'm not a TS developer. I imagine it might be marginally more performant to remove the event listener completely, but again I wasn't about the refactor anything else, just injected a condition that will never be met 😅.
